### PR TITLE
Fix tasks used to remove pkgs that have been ignored until now

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     purge=yes
   with_items: '{{ packages_to_remove }}'
 
-  name: remove packages (ubuntu14 only)
+- name: remove packages (ubuntu14 only)
   apt: >
     pkg={{ item }}
     state=absent
@@ -17,7 +17,7 @@
     - libcap-ng0
   when: ansible_distribution_version == '14.04'
 
-  name: remove packages (ubuntu18 only)
+- name: remove packages (ubuntu18 only)
   apt: >
     pkg={{ item }}
     state=absent


### PR DESCRIPTION
OS version-specific tasks that remove some packages have been executed up until now. I noticed this through `No package matching 'gdebi-core' is available` error, occurring when using latest version being released `v0.1.1`.

After this being merged, we should make a new release, cause the current one is unusable w/o workarounds