### PR TITLE
add runit-systemd on ubuntu 18 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
     install_recommends=no
   with_items:
     - resolvconf
+    - runit-systemd
   when: ansible_distribution_version == '18.04'
 
 - name: system apt upgrade


### PR DESCRIPTION
to allow runit-based services to continue to work (allowing to not have to rewrite certain service files to systemd unit files)

Relates to https://github.com/zinfra/backend-issues/issues/1509