### PR TITLE
Dbus needed for systemd collector

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
 - name: add packages (ubuntu18 only)
   apt:
     pkg:
+      - dbus
       - runit-systemd
     state: latest
     install_recommends: false


### PR DESCRIPTION
Missing dbus leads to the following errors:
```
2021-02-01T12:39:54.500791+00:00 ip-10-90-133-104 2[667]: time="2021-02-01T12:39:54Z" level=error msg="ERROR: systemd collector failed after 0.001139s: couldn't get units: couldn't get dbus connection: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory" source="collector.go:132"
```