### PR TITLE
Remove DST Root CA X3 expiration from cert store

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,3 +126,12 @@
     value=2048
     sysctl_set=yes
     reload=yes
+
+- name: patch /etc/ca-certificates.conf
+  replace:
+    path: /etc/ca-certificates.conf
+    regexp: "^mozilla\/DST_Root_CA_X3.crt"
+    replace: "!mozilla/DST_Root_CA_X3.crt"
+
+- name: update cert store
+  command: update-ca-certificates


### PR DESCRIPTION
This patches the `/etc/ca-certificates.conf` file to remove `mozilla/DST_Root_CA_X3.crt` and runs `update-ca-certificates`.

Tasks tested in https://github.com/zinfra/cailleach/pull/650